### PR TITLE
Add self-contained video2text demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# video2text
+# Video2Text
+
+A simple demo application that converts audio or video to text. The frontend is built with HTML, Tailwind CSS and FontAwesome. The backend uses only the Node.js standard library so it can run without installing extra packages. The transcription logic is still a placeholder returning demo text.
+
+## Prerequisites
+
+- Node.js >= 14
+- npm
+
+## Setup
+
+There are no external dependencies, so nothing needs to be installed before running.
+
+## Run the application
+
+```bash
+npm start
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in your browser.
+
+## Notes
+
+This demo includes only placeholder logic for transcription. To make it production-ready you would integrate a real speech-to-text engine (for example Whisper or Vosk) inside `server/server.js` and handle a wider range of media formats.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Video2Text</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-b6shLFVvSdnF+mqbEs9pX00lUaGFU/ftn324KQl9iQudRP82LPgAvX8ZUBKbjDgq09NdXBJ+ci6/1zbN1hw1bw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body class="bg-gray-100 font-sans">
+  <div class="container mx-auto p-4">
+    <header class="text-center mb-8">
+      <h1 class="text-3xl font-bold mb-2">Video2Text</h1>
+      <p class="text-gray-700">Upload an audio/video file or provide a link to transcribe it into text.</p>
+    </header>
+
+    <section class="bg-white rounded shadow p-6 mb-8">
+      <h2 class="text-xl font-semibold mb-4"><i class="fa-solid fa-file-arrow-up mr-2"></i>Upload File</h2>
+      <form id="uploadForm" class="space-y-4">
+        <input type="file" name="file" class="border rounded p-2 w-full" accept="audio/*,video/*" required>
+        <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white rounded px-4 py-2">
+          <i class="fa-solid fa-cloud-arrow-up mr-1"></i>Upload & Transcribe
+        </button>
+      </form>
+      <pre id="uploadResult" class="bg-gray-100 p-2 mt-4 whitespace-pre-wrap"></pre>
+    </section>
+
+    <section class="bg-white rounded shadow p-6">
+      <h2 class="text-xl font-semibold mb-4"><i class="fa-solid fa-link mr-2"></i>Transcribe from Link</h2>
+      <form id="linkForm" class="space-y-4">
+        <input type="url" name="url" class="border rounded p-2 w-full" placeholder="https://example.com/audio.mp3" required>
+        <button type="submit" class="bg-green-500 hover:bg-green-600 text-white rounded px-4 py-2">
+          <i class="fa-solid fa-play mr-1"></i>Transcribe URL
+        </button>
+      </form>
+      <pre id="linkResult" class="bg-gray-100 p-2 mt-4 whitespace-pre-wrap"></pre>
+    </section>
+
+    <footer class="text-center mt-8 text-gray-500">
+      <p>Made with <i class="fa-solid fa-heart text-red-500"></i> for demo purposes.</p>
+      <img class="mx-auto mt-4 rounded" src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=80" alt="Ocean view" width="300">
+    </footer>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/client/script.js
+++ b/client/script.js
@@ -1,0 +1,30 @@
+document.getElementById('uploadForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const file = e.target.elements.file.files[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = async () => {
+    const base64 = reader.result.split(',')[1];
+    const res = await fetch('/api/upload', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename: file.name, data: base64 })
+    });
+    const data = await res.json();
+    document.getElementById('uploadResult').textContent = data.text || data.error;
+  };
+  reader.readAsDataURL(file);
+});
+
+document.getElementById('linkForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const url = e.target.elements.url.value;
+  const res = await fetch('/api/transcribe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url })
+  });
+  const data = await res.json();
+  document.getElementById('linkResult').textContent = data.text || data.error;
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "video2text",
+  "version": "1.0.0",
+  "description": "Simple audio/video to text converter web app",
+  "main": "server/server.js",
+  "scripts": {
+    "start": "node server/server.js",
+    "test": "echo \"No tests yet\""
+  },
+  "keywords": ["video", "audio", "transcription"],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {}
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,89 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const uploadsDir = path.join(__dirname, 'uploads');
+fs.mkdirSync(uploadsDir, { recursive: true });
+
+function sendFile(res, filePath) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      return res.end('Not found');
+    }
+    const ext = path.extname(filePath);
+    const typeMap = {
+      '.html': 'text/html',
+      '.js': 'application/javascript',
+      '.css': 'text/css',
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg'
+    };
+    res.writeHead(200, { 'Content-Type': typeMap[ext] || 'application/octet-stream' });
+    res.end(data);
+  });
+}
+
+function parseJson(req, cb) {
+  let body = '';
+  req.on('data', chunk => { body += chunk; });
+  req.on('end', () => {
+    try {
+      const data = JSON.parse(body || '{}');
+      cb(null, data);
+    } catch (e) {
+      cb(e);
+    }
+  });
+}
+
+async function transcribe(filePath) {
+  // Placeholder transcription logic. Replace with real STT engine.
+  return `Transcribed text for file ${path.basename(filePath)}`;
+}
+
+const server = http.createServer((req, res) => {
+  const parsed = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === 'GET') {
+    const file = parsed.pathname === '/' ? '/index.html' : parsed.pathname;
+    const filePath = path.join(__dirname, '..', 'client', file);
+    return sendFile(res, filePath);
+  }
+
+  if (req.method === 'POST' && parsed.pathname === '/api/upload') {
+    return parseJson(req, async (err, body) => {
+      if (err || !body.filename || !body.data) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'Invalid payload' }));
+      }
+      const buffer = Buffer.from(body.data, 'base64');
+      const saved = path.join(uploadsDir, `${Date.now()}_${body.filename}`);
+      fs.writeFileSync(saved, buffer);
+      const text = await transcribe(saved);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ text }));
+    });
+  }
+
+  if (req.method === 'POST' && parsed.pathname === '/api/transcribe') {
+    return parseJson(req, (err, body) => {
+      if (err || !body.url) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'No URL provided' }));
+      }
+      const text = `Transcribed text for media at ${body.url}`; // placeholder
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ text }));
+    });
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- reimplement Node server without external dependencies
- send uploaded files as base64 JSON from the browser
- update README to note Node-only setup and placeholder transcription

## Testing
- `npm test`
